### PR TITLE
Added support for static linking and rand

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,6 @@ homepage = "http://kissfft.sourceforge.net/"
 repository = "https://github.com/m13253/rust-kissfft"
 keywords = ["FFT", "signal"]
 build = "build.rs"
+
+[dependencies]
+rand = "0.3"

--- a/build.rs
+++ b/build.rs
@@ -42,5 +42,5 @@ fn main() {
             .status()
     };
     assert!(create_archive("kissfft", &objects).unwrap().success());
-    println!("cargo:rustc-flags=-L {} -l kissfft:static", out_dir);
+    println!("cargo:rustc-flags=-L {}", out_dir);
 }

--- a/src/binding.rs
+++ b/src/binding.rs
@@ -39,7 +39,7 @@ pub struct kiss_fft_cpx {
 pub struct kiss_fft_state;
 pub type kiss_fft_cfg = *mut kiss_fft_state;
 
-#[link = "kissfft"]
+#[link(name = "kissfft")]
 extern {
     pub fn kiss_fft_alloc(nfft: libc::c_int, inverse_fft: libc::c_int, mem: *mut libc::c_void, lenmem: *mut libc::size_t) -> kiss_fft_cfg;
     pub fn kiss_fft(cfg: kiss_fft_cfg, fin: *const kiss_fft_cpx, fout: *mut kiss_fft_cpx);

--- a/tests/random.rs
+++ b/tests/random.rs
@@ -15,13 +15,14 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 #![cfg(test)]
 
 extern crate kissfft;
+extern crate rand;
 
 #[test]
 fn test_random_fft() {
     let nfft = 1024;
     let mut kiss_fft = kissfft::KissFFT::new(nfft, false);
     let mut kiss_ifft = kissfft::KissFFT::new(nfft, true);
-    let fin = std::iter::repeat(()).map(|_| kissfft::interface::Complex::new(std::rand::random::<kissfft::Scalar>()*2.-1., std::rand::random::<kissfft::Scalar>()*2.-1.)).take(nfft).collect::<Vec<kissfft::Complex>>();
+    let fin = std::iter::repeat(()).map(|_| kissfft::interface::Complex::new(rand::random::<kissfft::Scalar>()*2.-1., rand::random::<kissfft::Scalar>()*2.-1.)).take(nfft).collect::<Vec<kissfft::Complex>>();
     let fout_fft = kiss_fft.transform_norm_to_vec(&*fin);
     let fout_ifft = kiss_ifft.transform_norm_to_vec(&*fout_fft);
     println!("\nIN   = [\n{}\n]", fin.iter().map(|x: &kissfft::Complex| format!("    {}", x)).collect::<Vec<String>>().connect(",\n"));


### PR DESCRIPTION
Now uses rand crate and allows rustc to infer static deps

running 1 test
test test_random_fft ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
